### PR TITLE
Bugfix to avoid breaking XML in case of special characters

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -215,7 +215,7 @@ class PrestaShopWebservice
 		}
 		else
 			throw new PrestaShopWebserviceException('Bad parameters given');
-		$request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'POST', CURLOPT_POSTFIELDS => 'xml='.$xml));
+		$request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'POST', CURLOPT_POSTFIELDS => 'xml='.urlencode($xml)));
 
 		self::checkStatusCode($request['status_code']);
 		return self::parseXML($request['response']);


### PR DESCRIPTION
In case xml contains special characters like the ampersand, the resulting xml in transport is broken. Urlencoding seems to help, see:

http://www.php.net/manual/en/function.curl-setopt-array.php

"As with curl_setopt(), passing an array to CURLOPT_POST will encode the data as multipart/form-data, while passing a URL-encoded string will encode the data as application/x-www-form-urlencoded."

Dunno if this is the optimal solution but seemed to help in my case.
