### PR TITLE
Flush libxml error buffer

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -185,6 +185,7 @@ class PrestaShopWebservice
 	{
 		if ($response != '')
 		{
+			libxml_clear_errors();
 			libxml_use_internal_errors(true);
 			$xml = simplexml_load_string($response);
 			if (libxml_get_errors())


### PR DESCRIPTION
Adding libxml_clear_errors() before using libxml to prevent previous errors from another lib using libxml