### PR TITLE
Fix XML error : String could not be parsed as XML

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -43,7 +43,7 @@ class PrestaShopWebservice
 	
 	/** @var array compatible versions of PrestaShop Webservice */
 	const psCompatibleVersionsMin = '1.4.0.17';
-	const psCompatibleVersionsMax = '1.6.0.5';
+	const psCompatibleVersionsMax = '1.6.0.9';
 	
 	/**
 	 * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated
@@ -219,7 +219,7 @@ class PrestaShopWebservice
 		}
 		else
 			throw new PrestaShopWebserviceException('Bad parameters given');
-		$request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'POST', CURLOPT_POSTFIELDS => 'xml='.urlencode($xml)));
+		$request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'POST', CURLOPT_POSTFIELDS => $xml));
 
 		self::checkStatusCode($request['status_code']);
 		return self::parseXML($request['response']);


### PR DESCRIPTION
1. Fixing CDATA[XML error : String could not be parsed as XML when adding products via WebService. More about problem here http://stackoverflow.com/questions/25526949/adding-products-to-prestashop-1-6-0-9-with-webservice
