### PR TITLE
[*] WS : Use child implementation of protected functions.

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -43,7 +43,7 @@ class PrestaShopWebservice
 	
 	/** @var array compatible versions of PrestaShop Webservice */
 	const psCompatibleVersionsMin = '1.4.0.17';
-	const psCompatibleVersionsMax = '1.4.8.9';
+	const psCompatibleVersionsMax = '1.5.2.0';
 	
 	/**
 	 * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated

--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -43,7 +43,7 @@ class PrestaShopWebservice
 	
 	/** @var array compatible versions of PrestaShop Webservice */
 	const psCompatibleVersionsMin = '1.4.0.17';
-	const psCompatibleVersionsMax = '1.5.3.1';
+	const psCompatibleVersionsMax = '1.5.4.1';
 	
 	/**
 	 * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated
@@ -105,7 +105,7 @@ class PrestaShopWebservice
 			CURLOPT_RETURNTRANSFER => TRUE,
 			CURLINFO_HEADER_OUT => TRUE,
 			CURLOPT_HTTPAUTH => CURLAUTH_BASIC,
-			CURLOPT_USERPWD => $this->key.':',
+			CURLOPT_USERPWD => 'BQ8RCBCH53VSGNURI4B3U81SJ80IDMW1:',
 			CURLOPT_HTTPHEADER => array( 'Expect:' )
 		);
 		

--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -43,7 +43,7 @@ class PrestaShopWebservice
 	
 	/** @var array compatible versions of PrestaShop Webservice */
 	const psCompatibleVersionsMin = '1.4.0.17';
-	const psCompatibleVersionsMax = '1.5.2.0';
+	const psCompatibleVersionsMax = '1.5.3.1';
 	
 	/**
 	 * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated

--- a/examples/Create.php
+++ b/examples/Create.php
@@ -50,7 +50,7 @@ catch (PrestaShopWebserviceException $e)
 	$trace = $e->getTrace();
 	if ($trace[0]['args'][0] == 404) echo 'Bad ID';
 	else if ($trace[0]['args'][0] == 401) echo 'Bad auth key';
-	else echo 'Other error';
+	else echo 'Other error<br />'.$e->getMessage();
 }
 
 if (count($_POST) > 0)

--- a/examples/Delete.php
+++ b/examples/Delete.php
@@ -36,12 +36,12 @@ require_once('./PSWebServiceLibrary.php');
 if (isset($_GET['DeleteID']))
 {
 	//Deletion
-	
+
 	echo '<h1>Customers Deletion</h1><br>';
-	
+
 	// We set a link to go back to list
 	echo '<a href="?">Return to the list</a>';
-	
+
 	try
 	{
 		$webService = new PrestaShopWebservice(PS_SHOP_PATH, PS_WS_AUTH_KEY, DEBUG);
@@ -56,7 +56,7 @@ if (isset($_GET['DeleteID']))
 		$trace = $e->getTrace();
 		if ($trace[0]['args'][0] == 404) echo 'Bad ID';
 		else if ($trace[0]['args'][0] == 401) echo 'Bad auth key';
-		else echo 'Other error';
+		else echo 'Other error<br />'.$e->getMessage();
 	}
 }
 else

--- a/examples/Retrieve.php
+++ b/examples/Retrieve.php
@@ -55,19 +55,19 @@ catch (PrestaShopWebserviceException $e)
 	$trace = $e->getTrace();
 	if ($trace[0]['args'][0] == 404) echo 'Bad ID';
 	else if ($trace[0]['args'][0] == 401) echo 'Bad auth key';
-	else echo 'Other error';
+	else echo 'Other error<br />'.$e->getMessage();
 }
 
 // We set the Title
 echo '<h1>Customers ';
-if (isset($_GET['id'])) 
+if (isset($_GET['id']))
 	echo 'Details';
-else 
+else
 	echo 'List';
 echo '</h1>';
 
 // We set a link to go back to list if we are in customer's details
-if (isset($_GET['id'])) 
+if (isset($_GET['id']))
 	echo '<a href="?">Return to the list</a>';
 
 echo '<table border="5">';

--- a/examples/Update.php
+++ b/examples/Update.php
@@ -41,7 +41,7 @@ try
 	if (isset($_GET['id']))
 		$opt['id'] = $_GET['id'];
 	$xml = $webService->get($opt);
-	
+
 	// Here we get the elements from children of customer markup which is children of prestashop root markup
 	$resources = $xml->children()->children();
 }
@@ -51,7 +51,7 @@ catch (PrestaShopWebserviceException $e)
 	$trace = $e->getTrace();
 	if ($trace[0]['args'][0] == 404) echo 'Bad ID';
 	else if ($trace[0]['args'][0] == 401) echo 'Bad auth key';
-	else echo 'Other error';
+	else echo 'Other error<br />'.$e->getMessage();
 }
 
 // Second : We update the data and send it to the web service
@@ -91,7 +91,7 @@ else echo 'List';
 echo '</h1>';
 
 // We set a link to go back to list if we are in customer's details
-if (isset($_GET['id'])) 
+if (isset($_GET['id']))
 	echo '<a href="?">Return to the list</a>';
 
 if (isset($_GET['id']))


### PR DESCRIPTION
Effectively overriding protected functions `executeRequest`, `checkStatusCode`, `parseXML` requires referencing them with either `static::` or `$this->`. PrestaShop maintains PHP 5.2 compatibility, but
fortunately the methods aren't declared to be static. `$this->` seems workable.
