### PR TITLE
Composer requires license identifier, no title+url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "prestashop/prestashop-webservice-lib",
     "description": "PrestaShop Webservice access library",
-    "license": "http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)",
+    "license": "OSL-3.0",
     "authors": [
         {
             "name": "PrestaShop SA",


### PR DESCRIPTION
Here’s the [full list](https://spdx.org/licenses/) of license identifiers from which I took `"OSL-3.0"`