### PR TITLE
Add autoload instructions for full Composer compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,7 @@
             "email": "contact@prestashop.com"
         }
     ],
-    "require": {}
+    "autoload": {
+        "classmap": ["PSWebServiceLibrary.php"]
+    }
 }


### PR DESCRIPTION
I’m hoping this will now make the library fully installable / usable with Composer; it seems to work locally on my machine, but I had to manually manipulate Composer’s `installed.json` to test it, so I’m not 100% sure.