### PR TITLE
[-] WS : Updated psCompatibleVersionsMax to latest Prestashop version

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -46,7 +46,7 @@ class PrestaShopWebservice
 
 	/** @var array compatible versions of PrestaShop Webservice */
 	const psCompatibleVersionsMin = '1.4.0.0';
-	const psCompatibleVersionsMax = '1.6.0.14';
+	const psCompatibleVersionsMax = '1.6.1.0';
 	
 	/**
 	 * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated


### PR DESCRIPTION
Webservices calls with the latest version of PrestaShop were failing due to the psCompatibleVersionsMax constant not being updated.