### PR TITLE
Fix the Authentication problem

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -113,6 +113,8 @@ class PrestaShopWebservice
 			CURLOPT_HTTPHEADER => array( 'Expect:' )
 		);
 
+	        $url .= '&ws_key=' . $this->key;
+
 		$session = curl_init($url);
 
 		$curl_options = array();


### PR DESCRIPTION
without this line, the server keeps sending back following error:

Other error:
This call to PrestaShop Web Services failed and returned an HTTP status of 401. That means: Unauthorized.

but adding this lines works things out