### PR TITLE
Fix wrong relative path in examples

### DIFF
--- a/examples/Create.php
+++ b/examples/Create.php
@@ -31,7 +31,7 @@
 define('DEBUG', true);
 define('PS_SHOP_PATH', 'http://www.myshop.com/');
 define('PS_WS_AUTH_KEY', 'ZQ88PRJX5VWQHCWE4EE7SQ7HPNX00RAJ');
-require_once('./PSWebServiceLibrary.php');
+require_once('../PSWebServiceLibrary.php');
 
 // Here we use the WebService to get the schema of "customers" resource
 try

--- a/examples/CustomersList.php
+++ b/examples/CustomersList.php
@@ -31,7 +31,7 @@
 define('DEBUG', true);											// Debug mode
 define('PS_SHOP_PATH', 'http://www.myshop.com/');		// Root path of your PrestaShop store
 define('PS_WS_AUTH_KEY', 'ZQ88PRJX5VWQHCWE4EE7SQ7HPNX00RAJ');	// Auth key (Get it in your Back Office)
-require_once('./PSWebServiceLibrary.php');
+require_once('../PSWebServiceLibrary.php');
 
 // Here we make the WebService Call
 try

--- a/examples/Delete.php
+++ b/examples/Delete.php
@@ -31,7 +31,7 @@
 define('DEBUG', true);
 define('PS_SHOP_PATH', 'http://www.myshop.com/');
 define('PS_WS_AUTH_KEY', 'ZQ88PRJX5VWQHCWE4EE7SQ7HPNX00RAJ');
-require_once('./PSWebServiceLibrary.php');
+require_once('../PSWebServiceLibrary.php');
 
 if (isset($_GET['DeleteID']))
 {

--- a/examples/Retrieve.php
+++ b/examples/Retrieve.php
@@ -31,7 +31,7 @@
 define('DEBUG', true);											// Debug mode
 define('PS_SHOP_PATH', 'http://www.myshop.com/');							// Root path of your PrestaShop store
 define('PS_WS_AUTH_KEY', 'ZQ88PRJX5VWQHCWE4EE7SQ7HPNX00RAJ');	// Auth key (Get it in your Back Office)
-require_once('./PSWebServiceLibrary.php');
+require_once('../PSWebServiceLibrary.php');
 
 // Here we make the WebService Call
 try

--- a/examples/Update.php
+++ b/examples/Update.php
@@ -31,7 +31,7 @@
 define('DEBUG', true);
 define('PS_SHOP_PATH', 'http://www.myshop.com/');
 define('PS_WS_AUTH_KEY', 'VIVELADIVISIONMOBILEDEPRESTASHOP');
-require_once('./PSWebServiceLibrary.php');
+require_once('../PSWebServiceLibrary.php');
 
 // First : We always get the customer's list or a specific one
 try


### PR DESCRIPTION
Warning: require_once(./PSWebServiceLibrary.php): failed to open stream
Fatal error: require_once(): Failed opening required './PSWebServiceLibrary.php'
