### PR TITLE
Trim webservice's response before XML parsing.

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -199,7 +199,7 @@ class PrestaShopWebservice
 		{
 			libxml_clear_errors();
 			libxml_use_internal_errors(true);
-			$xml = simplexml_load_string($response,'SimpleXMLElement', LIBXML_NOCDATA);
+			$xml = simplexml_load_string(trim($response),'SimpleXMLElement', LIBXML_NOCDATA);
 			if (libxml_get_errors())
 			{
 				$msg = var_export(libxml_get_errors(), true);


### PR DESCRIPTION
In order to avoid errors like 'XML declaration allowed only at the start of the
document', trimming trailing whitespaces is necessary.

Signed-off-by: Piyush Pangtey <piyush@newgenpayments.com>