### PR TITLE
Fix: urldecode() expects parameter 1 to be string, on line 174

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -215,7 +215,7 @@ class PrestaShopWebservice
         curl_close($session);
         if ($this->debug) {
             if ($curl_params[CURLOPT_CUSTOMREQUEST] == 'PUT' || $curl_params[CURLOPT_CUSTOMREQUEST] == 'POST') {
-                $this->printDebug('XML SENT', urldecode($curl_params[CURLOPT_POSTFIELDS]));
+                $this->printDebug('XML SENT', urldecode(var_export($curl_params[CURLOPT_POSTFIELDS], true)));
             }
             if ($curl_params[CURLOPT_CUSTOMREQUEST] != 'DELETE' && $curl_params[CURLOPT_CUSTOMREQUEST] != 'HEAD') {
                 $this->printDebug('RETURN HTTP BODY', $body);


### PR DESCRIPTION
I'm getting 500 errors when debug is enabled (passing array to urldecode()).