### PR TITLE
Add 'schema' to resources, then you can use $opt['schema'] = 'blank';

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -345,7 +345,7 @@ class PrestaShopWebservice
                 $url .= '/' . $options['id'];
             }
 
-            $params = array('filter', 'display', 'sort', 'limit', 'id_shop', 'id_group_shop');
+            $params = array('filter', 'display', 'sort', 'limit', 'id_shop', 'id_group_shop', 'schema');
             foreach ($params as $p) {
                 foreach ($options as $k => $o) {
                     if (strpos($k, $p) !== false) {


### PR DESCRIPTION
Old write:
$xml = $webService->get(array('url' => 'http://example.com/api/customers?schema=blank'));

Now you can:
$xml = $webService->get([
  'schema' => 'blank'
]);