### PR TITLE
Feature/agent

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -105,6 +105,7 @@ class PrestaShopWebservice
 	protected function executeRequest($url, $curl_params = array())
 	{
 		$defaultParams = array(
+			CURLOPT_USERAGENT      => "Fashionalia/1.0",
 			CURLOPT_HEADER => TRUE,
 			CURLOPT_RETURNTRANSFER => TRUE,
 			CURLINFO_HEADER_OUT => TRUE,


### PR DESCRIPTION
Para Odisel:

Si no hay user agent nos salta 403, no autorizado (redirección interna suya que se carga los parámetros?¿? o error standard) 

ejecuté algún scraper más y no afecta el header nuevo. 
