### PR TITLE
Vary debug output when running at cli

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -180,7 +180,11 @@ class PrestaShopWebservice
 
 	public function printDebug($title, $content)
 	{
-		echo '<div style="display:table;background:#CCC;font-size:8pt;padding:7px"><h6 style="font-size:9pt;margin:0">'.$title.'</h6><pre>'.htmlentities($content).'</pre></div>';
+		if (php_sapi_name() == 'cli') {
+			echo $title.PHP_EOL.$content;
+		} else {
+			echo '<div style="display:table;background:#CCC;font-size:8pt;padding:7px"><h6 style="font-size:9pt;margin:0">'.$title.'</h6><pre>'.htmlentities($content).'</pre></div>';
+		}
 	}
 
 	public function getVersion()


### PR DESCRIPTION
If using this lib at the command line, the debug output is difficult to use
encoded with htmlentities() so use php_sapi_name() to detect cli environment
and just output the raw debug text without any encoding if we are at the cli.