### PR TITLE
Add 'language' support to resources

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -345,7 +345,7 @@ class PrestaShopWebservice
                 $url .= '/' . $options['id'];
             }
 
-            $params = array('filter', 'display', 'sort', 'limit', 'id_shop', 'id_group_shop', 'schema');
+            $params = array('filter', 'display', 'sort', 'limit', 'id_shop', 'id_group_shop', 'schema', 'language');
             foreach ($params as $p) {
                 foreach ($options as $k => $o) {
                     if (strpos($k, $p) !== false) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Now it's possible to show attributes for a resource in a chosen language by specifying the language ID.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | None
| How to test?  | I included a brief guide below showing two scenarios.

# How to test

Language IDs in this example:

-   1: English
-   2: Spanish

## Scenario 1: retrieving product details in a chosen language

PHP code:

```php
<?php

require_once 'vendor/autoload.php';

$ws = new PrestaShopWebservice($URL, $KEY, $DEBUG);

$opt = array(
    'resource' => 'products',
    'language' => 2,
    'id' => 42
);

$xml = $ws->get($opt);
```

HTTP request header:

```http
GET //api/products/42?language=2 HTTP/1.1
Host: localhost:8080
Authorization: Basic 12345678901234567890123456789012345678901234
Accept: */*
```

XML result:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<prestashop xmlns:xlink="http://www.w3.org/1999/xlink">
    <product>
        ...
        <id>
            <![CDATA[42]]>
        </id>
        <name>
            <language id="2" xlink:href="http://localhost:8080/api/languages/2">
                <![CDATA[Camiseta]]>
            </language>
        </name>
        <description>
            <language id="2" xlink:href="http://localhost:8080/api/languages/2">
                <![CDATA[<p>Una camiseta guay.</p>]]>
            </language>
        </description>
        ...
    </product>
</prestashop>
```

## Scenario 2: retrieving product details in every available language

If you don't pass `language`, it'll return the corresponding fields in all the languages ​​in which your store is configured.

PHP code:

```php
<?php

require_once 'vendor/autoload.php';

$ws = new PrestaShopWebservice($URL, $KEY, $DEBUG);

$opt = array(
    'resource' => 'products',
    'id' => 42
);

$xml = $ws->get($opt);
```

HTTP request header:

```http
GET //api/products/42 HTTP/1.1
Host: localhost:8080
Authorization: Basic 12345678901234567890123456789012345678901234
Accept: */*
```

XML result:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<prestashop xmlns:xlink="http://www.w3.org/1999/xlink">
    <product>
        ...
        <id>
            <![CDATA[42]]>
        </id>
        <name>
            <language id="1" xlink:href="http://localhost:8080/api/languages/1">
                <![CDATA[T-shirt]]>
            </language>
            <language id="2" xlink:href="http://localhost:8080/api/languages/2">
                <![CDATA[Camiseta]]>
            </language>
        </name>
        <description>
            <language id="1" xlink:href="http://localhost:8080/api/languages/1">
                <![CDATA[<p>A cool T-shirt.</p>]]>
            </language>
            <language id="2" xlink:href="http://localhost:8080/api/languages/2">
                <![CDATA[<p>Una camiseta guay.</p>]]>
            </language>
        </description>
        ...
    </product>
</prestashop>
```
