### PR TITLE
Fix PUT when url arg is provided

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -420,9 +420,7 @@ class PrestaShopWebservice
     public function edit($options)
     {
         $xml = '';
-        if (isset($options['url'])) {
-            $url = $options['url'];
-        } elseif ((isset($options['resource'], $options['id']) || isset($options['url'])) && $options['putXml']) {
+        if ((isset($options['resource'], $options['id']) || isset($options['url'])) && $options['putXml']) {
             $url = (isset($options['url']) ? $options['url'] :
                 $this->url . '/api/' . $options['resource'] . '/' . $options['id']);
             $xml = $options['putXml'];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | No xml sent when url is provided
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes #70.
| How to test?  | $webService->edit(['url' => $url, 'putXml' => $xml->asXML()])
