### PR TITLE
Added support until PS 8.1

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -47,7 +47,7 @@ class PrestaShopWebservice
     /** @var string Minimal version of PrestaShop to use with this library */
     const psCompatibleVersionsMin = '1.4.0.0';
     /** @var string Maximal version of PrestaShop to use with this library */
-    const psCompatibleVersionsMax = '1.7.99.99';
+    const psCompatibleVersionsMax = '8.1.1';
 
     /**
      * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated


### PR DESCRIPTION
Added support until PS 8.1

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Allow usage of the webservice-lib with PrestaShop 8.1 (`develop` branch today)
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Try to use webservice-lib with PrestaShop 8.1 (`develop` branch today). It does not work without this PR
| Possible impacts? | None