### PR TITLE
Update psCompatibleVersionsMax in PSWebServiceLibrary.php to support PS 8.1.2

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -47,7 +47,7 @@ class PrestaShopWebservice
     /** @var string Minimal version of PrestaShop to use with this library */
     const psCompatibleVersionsMin = '1.4.0.0';
     /** @var string Maximal version of PrestaShop to use with this library */
-    const psCompatibleVersionsMax = '8.1.1';
+    const psCompatibleVersionsMax = '8.1.2';
 
     /**
      * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description      | Change the maximum supported version for compatibility with PrestaShop 8.1.2
| Type             | improvement
| BC breaks        | no
| Deprecations     | no
| Fixed ticket     | none
How to test      | Try using accessing any resource on PrestaShop 8.1.2 using the library