### PR TITLE
Separate headers and response body using CURLINFO_HEADER_SIZE flag

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -192,13 +192,13 @@ class PrestaShopWebservice
         curl_setopt_array($session, $curl_options);
         $response = curl_exec($session);
 
-        $index = strpos($response, "\r\n\r\n");
-        if ($index === false && $curl_params[CURLOPT_CUSTOMREQUEST] != 'HEAD') {
+        $headerSize = curl_getinfo($session, CURLINFO_HEADER_SIZE);
+        if ($headerSize === false && $curl_params[CURLOPT_CUSTOMREQUEST] != 'HEAD') {
             throw new PrestaShopWebserviceException('Bad HTTP response ' . $response . curl_error($session));
         }
 
-        $header = substr($response, 0, $index);
-        $body = substr($response, $index + 4);
+        $header = substr($response, 0, $headerSize);
+        $body = substr($response, $headerSize);
 
         $headerArrayTmp = explode("\n", $header);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | separate headers and response body using CURLINFO_HEADER_SIZE
| Type?             | bug fix
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #[95](https://github.com/PrestaShop/PrestaShop-webservice-lib/issues/95)
| Sponsor company   | NxtLvl B.V.
| How to test?      | N/A
