### PR TITLE
Improve security for lib_xml

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -274,7 +274,13 @@ class PrestaShopWebservice
         if ($response != '') {
             libxml_clear_errors();
             libxml_use_internal_errors(true);
-            $xml = simplexml_load_string(trim($response), 'SimpleXMLElement', LIBXML_NOCDATA);
+            if (LIBXML_VERSION < 20900) {
+                // Avoid load of external entities (security problem).
+                // Required only if LIBXML_VERSION < 20900
+                libxml_disable_entity_loader(true);
+            }
+
+            $xml = simplexml_load_string(trim($response), 'SimpleXMLElement', LIBXML_NOCDATA|LIBXML_NONET);
             if (libxml_get_errors()) {
                 $msg = var_export(libxml_get_errors(), true);
                 libxml_clear_errors();


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Security fix for libxml. Call libxml_disable_entity_loader(true) and add LIBXML_NONET option for simplexml_load_string.
| Type?             | security fix
| BC breaks?        | no
| Deprecations?     | yes - libxml_disable_entity_loader not supported in reent PHP8.x - but protected with LIBXML_VERSION test
| Fixed ticket?     | None
| Sponsor company   | Applied in Dolibarr (not specifically sponsor company).
| How to test?      | Test multiple PHP versions, regression test.
