### PR TITLE
Increase max Ps version

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -47,7 +47,7 @@ class PrestaShopWebservice
     /** @var string Minimal version of PrestaShop to use with this library */
     const psCompatibleVersionsMin = '1.4.0.0';
     /** @var string Maximal version of PrestaShop to use with this library */
-    const psCompatibleVersionsMax = '8.1.1';
+    const psCompatibleVersionsMax = '8.1.4';
 
     /**
      * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The max ps version is fixed to 8.1.1, so if your instance is superior to this version it does not work, with exception "This library is not compatible with this version of PrestaShop. Please upgrade/downgrade this library"
| Type?             | bug fix
| BC breaks?        | yes 
| Deprecations?     |no
| Fixed ticket?     | 
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Try to use the library on the last Prestashop version 8.1.4 and it should works
