### PR TITLE
Handle lowercase psws-version header

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -211,6 +211,10 @@ class PrestaShopWebservice
             }
         }
 
+        if (!array_key_exists('PSWS-Version', $headerArray) && array_key_exists('psws-version', $headerArray)) {
+            $headerArray['PSWS-Version'] = $headerArray['psws-version'];
+        }
+
         if (array_key_exists('PSWS-Version', $headerArray)) {
             $this->version = $headerArray['PSWS-Version'];
             if (


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Handle lowercase psws-version header
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes the issue below
| Sponsor company   | 
| How to test?      | Modify the PrestaShop HTTP response header to make sure the header `PSWS-Version` is received as `psws-version`

### Issue content

It seems that some web servers return this header in lowercase. This causes the version compatibility check to be ignored because the library expects the header to be exactly 'PSWS-Version':
https://github.com/PrestaShop/PrestaShop-webservice-lib/blob/94feb5f547b4a33cd9c759edfa581f30fa42803b/PSWebServiceLibrary.php#L214

Example response:

```
HTTP/1.1 200 OK
Connection: Keep-Alive
Keep-Alive: timeout=5, max=100
access-time: 1701712674
x-powered-by: PrestaShop Webservice
psws-version: 8.1.2
content-type: text/xml;charset=utf-8
execution-time: 0.005
...
server: LiteSpeed
vary: User-Agent
```