### PR TITLE
Fix: PSWebServiceLibrary with sendemail=1 parameter does not work

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -448,9 +448,7 @@ class PrestaShopWebservice
     public function edit($options)
     {
         $xml = '';
-        if (isset($options['url'])) {
-            $url = $options['url'];
-        } elseif ((isset($options['resource'], $options['id']) || isset($options['url'])) && $options['putXml']) {
+        if ((isset($options['resource'], $options['id']) || isset($options['url'])) && $options['putXml']) {
             $url = (isset($options['url']) ? $options['url'] :
                 $this->url . '/api/' . $options['resource'] . '/' . $options['id']);
             $xml = $options['putXml'];
@@ -460,6 +458,8 @@ class PrestaShopWebservice
             if (isset($options['id_group_shop'])) {
                 $url .= '&id_group_shop=' . $options['id_group_shop'];
             }
+        } elseif (isset($options['url'])) {
+            $url = $options['url'];
         } else {
             throw new PrestaShopWebserviceException('Bad parameters given');
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In case of updating the order_carrier entity via webservice, passing the sendmail parameter the system does not work.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#37249](https://github.com/PrestaShop/PrestaShop/issues/37249)
| Sponsor company   | @codencode
| How to test?      | see https://github.com/PrestaShop/PrestaShop/issues/37249
