### PR TITLE
Add useragent to curl request

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -152,6 +152,7 @@ class PrestaShopWebservice
             CURLOPT_HTTPAUTH => CURLAUTH_BASIC,
             CURLOPT_USERPWD => $this->key . ':',
             CURLOPT_HTTPHEADER => array('Expect:'),
+            CURLOPT_USERAGENT => ['useragent'=>'Mozilla/5.0 (Android 13; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0']
             //CURLOPT_SSL_VERIFYPEER => false, // reminder, in dev environment sometimes self-signed certificates are used
             //CURLOPT_CAINFO => "PATH2CAINFO", // ssl certificate chain checking
             //CURLOPT_CAPATH => "PATH2CAPATH",


### PR DESCRIPTION
In some cases, useragent is null
And when calling a PS API hosted in OVH provider, the request is refused (the HTTP response code is 302)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add useragent to curl request, because it's sometimes empty, and the request is refused
| Type?             | misfunction with some providers like OVH

