### PR TITLE
Update maximal PrestaShop version compatibility to 8.2.3

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -47,7 +47,7 @@ class PrestaShopWebservice
     /** @var string Minimal version of PrestaShop to use with this library */
     const psCompatibleVersionsMin = '1.4.0.0';
     /** @var string Maximal version of PrestaShop to use with this library */
-    const psCompatibleVersionsMax = '8.2.0';
+    const psCompatibleVersionsMax = '8.2.3';
 
     /**
      * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated


### PR DESCRIPTION
**Description**
Updated the maximum compatible PrestaShop version from 8.2.0 to 8.2.3 in the `psCompatibleVersionsMax` constant to support the latest PrestaShop releases.

**Type**
improvement

**BC breaks:**
no

**Deprecations:**
no

**How to test:**
1. Verify that `PSWebServiceLibrary.php` line 50 shows `const psCompatibleVersionsMax = '8.2.3';`
2. Test the library with PrestaShop version 8.2.3 to confirm compatibility
3. Ensure no version compatibility errors are thrown when connecting to a PrestaShop 8.2.3 instance